### PR TITLE
update act to v0.2.34

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,16 +15,6 @@ steps:
   - go test ./...
   - sh scripts/build.sh
 
-- name: publish (dry run)
-  image: plugins/docker
-  pull: if-not-exists
-  settings:
-    dry_run: true
-    repo: plugins/github-actions
-    dockerfile: docker/Dockerfile.linux.amd64
-    tags:
-    - latest
-
 - name: publish
   image: plugins/docker
   pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,15 @@ steps:
   - go test ./...
   - sh scripts/build.sh
 
+- name: publish (dry run)
+  image: plugins/docker
+  pull: if-not-exists
+  settings:
+    dry_run: true
+    repo: plugins/github-actions
+    auto_tag: true
+    dockerfile: docker/Dockerfile.linux.amd64
+
 - name: publish
   image: plugins/docker
   pull: if-not-exists
@@ -26,3 +35,6 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
+  when:
+    event:
+    - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,8 +21,9 @@ steps:
   settings:
     dry_run: true
     repo: plugins/github-actions
-    auto_tag: true
     dockerfile: docker/Dockerfile.linux.amd64
+    tags:
+    - latest
 
 - name: publish
   image: plugins/docker

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "action-image",
 			Usage:  "Image to use for running github actions",
-			Value:  "node:12-buster-slim",
+			Value:  "node:16-buster-slim",
 			EnvVar: "PLUGIN_ACTION_IMAGE",
 		},
 		cli.StringFlag{

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -3,7 +3,7 @@ FROM docker:dind
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
 RUN apk add --no-cache ca-certificates curl
-RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sh -s v0.2.24
+RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sh -s v0.2.34
 
 ADD release/linux/amd64/plugin /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/plugin"]


### PR DESCRIPTION
this also required updating the action image to node16

this is a potentially breaking change, so I don't think we want this plugin image to be tagged 'latest' if/when this change is merged to main

I have also updated the drone pipeline to only publish the image on tag events, so if we give a proper tag (maybe 2.0.0) this updated plugin image will be available as plugins/github-actions:2 which will not break existing pipelines pulling latest