### PR TITLE
feat: expose actor argument

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,6 +81,11 @@ func main() {
 			Usage:  "Webhook event payload",
 			EnvVar: "PLUGIN_EVENT_PAYLOAD",
 		},
+		cli.StringFlag{
+			Name:   "actor",
+			Usage:  "User that triggered the event",
+			EnvVar: "PLUGIN_ACTOR",
+		},
 
 		// daemon flags
 		cli.StringFlag{
@@ -179,6 +184,7 @@ func run(c *cli.Context) error {
 			Verbose:      c.Bool("action-verbose"),
 			Image:        c.String("action-image"),
 			EventPayload: c.String("event-payload"),
+			Actor:        c.String("actor"),
 		},
 		Daemon: daemon.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/plugin.go
+++ b/plugin.go
@@ -64,10 +64,14 @@ func (p Plugin) Exec() error {
 		secretFile,
 		"--env-file",
 		envFile,
-		"--actor",
-		p.Action.Actor,
 		"-b",
 		"--detect-event",
+	}
+
+	// optional arguments
+	if p.Action.Actor != "" {
+		cmdArgs = append(cmdArgs, "--actor")
+		cmdArgs = append(cmdArgs, p.Action.Actor)
 	}
 
 	if p.Action.EventPayload != "" {

--- a/plugin.go
+++ b/plugin.go
@@ -30,6 +30,7 @@ type (
 		Env          map[string]string
 		Image        string
 		EventPayload string // Webhook event payload
+		Actor        string
 		Verbose      bool
 	}
 
@@ -63,6 +64,8 @@ func (p Plugin) Exec() error {
 		secretFile,
 		"--env-file",
 		envFile,
+		"--actor",
+		p.Action.Actor,
 		"-b",
 		"--detect-event",
 	}


### PR DESCRIPTION
# problem

A harness user is trying to use a github action composite while attempting to migrate from GHA to harness CIE. In doing so they attempted to use an image that relied on GITHUB_ACTOR env var, but were unable to set this var in the CI step.

Upon investigation it seems that this ENV var is set by the `nektos/act` cmd and not souced from the env.

# solution

Add another setting to the plugin for an actor, and pass this thru to the same actor argument in act.

Source of the option in act: https://github.com/nektos/act/blob/master/cmd/root.go#L66

You can leave the setting out and it reverts back to the default of `nektos/act`

# testing

There were no docs for what tests to do when contributing here, so I made my changes, linted the code, use the drone config to push my version to my own image `rssnyder/github-actions` and ran an action that would verify I was able to set the github actor.

## before

```yaml
              - step:
                  type: Plugin
                  name: debug
                  identifier: debug
                  spec:
                    connectorRef: account.dockerhub
                    image: plugins/github-actions
                    privileged: true
                    settings:
                      uses: rssnyder/public-action-step@main
                      with:
                        who-to-greet: <+pipeline.executionId>
                      env:
                        GITHUB_ACTOR: custom_actor
                    envVariables:
                      GITHUB_ACTOR: custom_actor
```

![image](https://user-images.githubusercontent.com/7338312/211389967-e7492fb5-bb13-4347-955d-b10959f8f9a6.png)

Execution link: https://app.harness.io/ng/#/account/wlgELJ0TTre5aZhzpt8gVA/cd/orgs/default/projects/development/pipelines/plugin/executions/hytRolBBRAiHGQPsuyBt1g/pipeline?stage=lhOy6gGlS5-Q_J2nUox0CQ&step=Er7aTlfbSk6oP4UX9gaK9w

## after

```yaml
               - step:
                  type: Plugin
                  name: debug
                  identifier: debug
                  spec:
                    connectorRef: account.dockerhub
                    image: rssnyder/github-actions
                    privileged: true
                    settings:
                      actor: custom_actor
                      uses: rssnyder/public-action-step@main
                      with:
                        who-to-greet: <+pipeline.executionId>
```

![image](https://user-images.githubusercontent.com/7338312/211390306-552d011b-3edc-451e-870c-0eee7be59481.png)

Execution link: https://app.harness.io/ng/#/account/wlgELJ0TTre5aZhzpt8gVA/cd/orgs/default/projects/development/pipelines/plugin/executions/EObWRJsBSgWhN8s4fzizvA/pipeline?stage=kygRQHDiT6KjyhSg3sORcQ&step=yoU-3_XJTwq4aUw-gpuv1g