### PR TITLE
Updated act to version 0.2.61

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -3,7 +3,7 @@ FROM docker:dind
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
 RUN apk add --no-cache ca-certificates curl
-RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sh -s v0.2.34
+RUN curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | sh -s v0.2.61
 
 ADD release/linux/amd64/plugin /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/plugin"]


### PR DESCRIPTION
Updated act to latest version 0.2.61.
This version will have support for node20 runtime.