### PR TITLE
(fix): Fix nested action outputs

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:dind
+FROM docker:29.6.0-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/plugin.go
+++ b/plugin.go
@@ -51,11 +51,11 @@ func (p Plugin) Exec() error {
 	}
 
 	ctx := context.Background()
-	repoURL, ref, ok := utils.ParseLookup(p.Action.Uses)
+	repoURL, ref, actionPath, ok := utils.ParseLookup(p.Action.Uses)
 	if !ok {
 		logrus.Warnf("Invalid 'uses' format: %s", p.Action.Uses)
 	}
-	logrus.Infof("Parsed 'uses' string. Repo: %s, Ref: %s", repoURL, ref)
+	logrus.Infof("Parsed 'uses' string. Repo: %s, Ref: %s, Path: %s", repoURL, ref, actionPath)
 
 	// Clone the GH Action repository using `cloner` with parsed repo and ref
 	clone := cloner.NewCache(cloner.NewDefault())
@@ -70,10 +70,14 @@ func (p Plugin) Exec() error {
 	outputVars := []string{}
 
 	if codedir != "" {
-		var err error
-		outputVars, err = utils.ParseActionOutputs(codedir)
+		actionDir, err := utils.ActionDir(codedir, actionPath)
 		if err != nil {
-			logrus.Warnf("Could not parse action.yml outputs from %s: %v", codedir, err)
+			logrus.Warnf("Invalid action path %q: %v", actionPath, err)
+		} else {
+			outputVars, err = utils.ParseActionOutputs(actionDir)
+			if err != nil {
+				logrus.Warnf("Could not parse action.yml outputs from %s: %v", actionDir, err)
+			}
 		}
 	}
 

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -60,14 +60,40 @@ func fileExists(path string) bool {
 	return !info.IsDir()
 }
 
+// ActionDir joins cloneDir with an optional action subdirectory.
+// Returns an error if actionPath escapes cloneDir.
+func ActionDir(cloneDir, actionPath string) (string, error) {
+	if actionPath == "" {
+		return cloneDir, nil
+	}
+
+	clean := filepath.Clean(actionPath)
+	if clean == "." || clean == "" {
+		return cloneDir, nil
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid action path: %s", actionPath)
+	}
+
+	actionDir := filepath.Join(cloneDir, clean)
+	rel, err := filepath.Rel(cloneDir, actionDir)
+	if err != nil {
+		return "", fmt.Errorf("invalid action path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("action path escapes clone dir: %s", actionPath)
+	}
+	return actionDir, nil
+}
+
 // ParseLookup parses the step string and returns the
-// associated repository and ref.
-func ParseLookup(s string) (repo string, ref string, ok bool) {
-	org, repo, _, ref, err := parseActionName(s)
+// associated repository, ref, and optional action subdirectory path.
+func ParseLookup(s string) (repo string, ref string, path string, ok bool) {
+	org, repoName, actionPath, ref, err := parseActionName(s)
 	if err == nil {
-		url := fmt.Sprintf("https://github.com/%s/%s", org, repo)
-		slog.Debug(fmt.Sprintf("parsed repo: %s, ref: %s", url, ref))
-		return url, ref, true
+		url := fmt.Sprintf("https://github.com/%s/%s", org, repoName)
+		slog.Debug(fmt.Sprintf("parsed repo: %s, ref: %s, path: %s", url, ref, actionPath))
+		return url, ref, actionPath, true
 	}
 
 	slog.Warn(fmt.Sprintf("failed to parse action name: %s with err: %v", s, err))
@@ -77,9 +103,9 @@ func ParseLookup(s string) (repo string, ref string, ok bool) {
 
 	slog.Debug("parsed repo", s)
 	if parts := strings.SplitN(s, "@", 2); len(parts) == 2 {
-		return parts[0], parts[1], true
+		return parts[0], parts[1], "", true
 	}
-	return s, "", true
+	return s, "", "", true
 }
 
 func parseActionName(action string) (org, repo, path, ref string, err error) {

--- a/utils/parse_test.go
+++ b/utils/parse_test.go
@@ -43,3 +43,93 @@ outputs:
 	assert.NoError(t, err)
 	assert.Empty(t, outputs)
 }
+
+func TestParseLookup(t *testing.T) {
+	tests := []struct {
+		name string
+		uses string
+		repo string
+		ref  string
+		path string
+		ok   bool
+	}{
+		{
+			name: "root action",
+			uses: "mathieudutour/github-tag-action@v6.2",
+			repo: "https://github.com/mathieudutour/github-tag-action",
+			ref:  "v6.2",
+			path: "",
+			ok:   true,
+		},
+		{
+			name: "nested action path",
+			uses: "my-corp/my-up2-action-external-management/.github/actions/mathieudutour/github-tag-action@v1",
+			repo: "https://github.com/my-corp/my-up2-action-external-management",
+			ref:  "v1",
+			path: ".github/actions/mathieudutour/github-tag-action",
+			ok:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, ref, path, ok := ParseLookup(tt.uses)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.repo, repo)
+			assert.Equal(t, tt.ref, ref)
+			assert.Equal(t, tt.path, path)
+		})
+	}
+}
+
+func TestActionDir(t *testing.T) {
+	clone := t.TempDir()
+
+	dir, err := ActionDir(clone, "")
+	assert.NoError(t, err)
+	assert.Equal(t, clone, dir)
+
+	dir, err = ActionDir(clone, ".github/actions/foo")
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(clone, ".github/actions/foo"), dir)
+
+	_, err = ActionDir(clone, "../outside")
+	assert.Error(t, err)
+}
+
+func TestParseActionOutputsNested(t *testing.T) {
+	clone := t.TempDir()
+	nested := filepath.Join(clone, ".github", "actions", "tag")
+	assert.NoError(t, os.MkdirAll(nested, 0755))
+
+	content := `
+outputs:
+  new_tag:
+    description: "Generated tag"
+  new_version:
+    description: "Generated version"
+`
+	assert.NoError(t, os.WriteFile(filepath.Join(nested, "action.yml"), []byte(content), 0644))
+
+	actionDir, err := ActionDir(clone, ".github/actions/tag")
+	assert.NoError(t, err)
+
+	outputs, err := ParseActionOutputs(actionDir)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, outputs, []string{"new_tag", "new_version"})
+
+	// Root still empty when only nested action.yml exists
+	outputs, err = ParseActionOutputs(clone)
+	assert.NoError(t, err)
+	assert.Empty(t, outputs)
+}
+
+func TestParseActionOutputsMissingNested(t *testing.T) {
+	clone := t.TempDir()
+	actionDir, err := ActionDir(clone, ".github/actions/missing")
+	assert.NoError(t, err)
+
+	outputs, err := ParseActionOutputs(actionDir)
+	assert.NoError(t, err)
+	assert.Empty(t, outputs)
+}

--- a/utils/parse_test.go
+++ b/utils/parse_test.go
@@ -95,6 +95,21 @@ func TestActionDir(t *testing.T) {
 
 	_, err = ActionDir(clone, "../outside")
 	assert.Error(t, err)
+
+	// Traversal that only escapes after filepath.Clean
+	_, err = ActionDir(clone, "foo/../../etc")
+	assert.Error(t, err)
+
+	_, err = ActionDir(clone, "foo/../..")
+	assert.Error(t, err)
+
+	_, err = ActionDir(clone, "foo/bar/../../../outside")
+	assert.Error(t, err)
+
+	// Clean keeps the result inside cloneDir — should succeed
+	dir, err = ActionDir(clone, "foo/../.github/actions/bar")
+	assert.NoError(t, err)
+	assert.Equal(t, filepath.Join(clone, ".github/actions/bar"), dir)
 }
 
 func TestParseActionOutputsNested(t *testing.T) {


### PR DESCRIPTION
## Summary
- Output discovery only looked at the cloned repo root `action.yml`, so path-based actions (`owner/repo/path/to/action@ref`) never exported outputs to Harness.
- `ParseLookup` now returns the action subdirectory, and we resolve `<clone>/<path>/action.yml` (with path-traversal guards). Root-level actions are unchanged.
- Fixes nested composite wrappers (e.g. `.github/actions/...`) that run successfully but leave Harness output variables empty (`No output variables detected in action.yml; skipping output file generation.`).
- Pins the plugin base image from floating `docker:dind` to `docker:29.6.0-dind` to avoid Docker 29.7.0 `CopyToContainer` regression (`path escapes from parent` under `/var/run/act`).
- Adds unit coverage for nested path discovery and `ActionDir` traversal cases that only escape after `filepath.Clean`.

## Test plan
- [x] Unit tests for root vs nested `uses`, nested outputs, missing nested `action.yml` soft-fail, and path-traversal rejection
- [x] Verified via Docker: `docker run --rm -v "$PWD":/src -w /src golang:1.22.7 go test ./... -count=1 -v`
- [x] Built temp image and validated nested action in Harness (`fjunior87/ci-py-test/.github/actions/sample-tag@main`)
  - Logs show `Path: .github/actions/sample-tag`
  - `output variables` step runs
  - Harness step outputs populated (`new_tag`, `new_version`)
- [x] Confirmed old `plugins/github-actions:latest` fails the same nested repro (empty outputs)
- [x] Validated root action (`mathieudutour/github-tag-action@v6.2`) with pinned DinD base — no `path escapes from parent` failure; outputs exported

