### PR TITLE
fix: [CI-24235]: clone SHA-pinned GitHub Actions by commit hash so outputs are discovered

### DIFF
--- a/cloner/util.go
+++ b/cloner/util.go
@@ -17,8 +17,8 @@ var (
 	semver = regexp.MustCompile(`^v?((([0-9]+)(?:\.([0-9]+))?(?:\.([0-9]+))?(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$`)
 )
 
-// helper function returns true if the string is a commit hash.
-func isHash(s string) bool {
+// IsHash returns true if the string is a sha1 or sha256 commit hash.
+func IsHash(s string) bool {
 	return sha1.MatchString(s) || sha256.MatchString(s)
 }
 

--- a/cloner/util_test.go
+++ b/cloner/util_test.go
@@ -52,6 +52,11 @@ func TestIsHash(t *testing.T) {
 			name: "f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b",
 			tag:  true,
 		},
+		// CI-24235: SHA-pinned `uses:` ref (tj-actions/changed-files@<sha>)
+		{
+			name: "ed68ef82c095e0d48ec87eccea555d944a631a4c",
+			tag:  true,
+		},
 		// not a sha
 		{
 			name: "aacad6e",
@@ -75,7 +80,7 @@ func TestIsHash(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if got, want := isHash(test.name), test.tag; got != want {
+		if got, want := IsHash(test.name), test.tag; got != want {
 			t.Errorf("Detected hash %v, want %v", got, want)
 		}
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -57,9 +57,19 @@ func (p Plugin) Exec() error {
 	}
 	logrus.Infof("Parsed 'uses' string. Repo: %s, Ref: %s", repoURL, ref)
 
+	// When the action is pinned to a full commit SHA (e.g. owner/action@<sha>),
+	// the ref cannot be resolved via refs/heads/* or refs/tags/*. Pass it as the
+	// sha instead so the cloner checks out the commit directly.
+	sha := ""
+	if cloner.IsHash(ref) {
+		sha = ref
+		ref = ""
+		logrus.Infof("Ref is a commit SHA; cloning by sha: %s", sha)
+	}
+
 	// Clone the GH Action repository using `cloner` with parsed repo and ref
 	clone := cloner.NewCache(cloner.NewDefault())
-	codedir, cloneErr := clone.Clone(ctx, repoURL, ref, "")
+	codedir, cloneErr := clone.Clone(ctx, repoURL, ref, sha)
 	if cloneErr != nil {
 		logrus.Warnf("Failed to clone GH Action: %v", cloneErr)
 	} else {


### PR DESCRIPTION
## Summary
- Fixes [CI-24235](https://harness.atlassian.net/browse/CI-24235) / ZD-121740: when a GitHub Actions Plugin step pins `uses:` to a full commit SHA, the action still runs, but Harness does not surface its output variables.
- Root cause: the plugin clones the action repo only to parse `action.yml` for output names. It always passed `sha=""`, so a SHA ref was treated as a branch/tag (`refs/heads/<sha>` then `refs/tags/<sha>`). That clone failed, `ParseActionOutputs` was skipped, and the Output tab stayed empty. `isHash()` already existed but was unused.
- Fix: if the parsed ref is a commit hash (`IsHash`), pass it as `sha` and clear `ref` so the existing SHA checkout path runs. Tag/branch refs are unchanged.

## Test plan
- [x] `go test ./cloner/...` and `go build ./...`
- [x] Local Harness pipeline, stock `plugins/github-actions`:
  - `actions/github-script@v7` → Output tab has `result = hello-from-action`
  - `actions/github-script@f28e40c7...` (same commit as v7) → action succeeds, Output tab empty
- [x] Same pipeline with `vinayakharness/github-actions:ci-24235-debug` → both tag and SHA steps expose `result`

## Customer mapping
Same mechanism as BBC (`tj-actions/changed-files@<sha>`): action execution is independent of the output-discovery clone. Reproduced with `github-script` so the action itself would succeed locally. After merge, publish a new `plugins/github-actions` tag.


Made with [Cursor](https://cursor.com)

[CI-24235]: https://harness.atlassian.net/browse/CI-24235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ